### PR TITLE
Add 'is' attr to replace root tag

### DIFF
--- a/Number.vue
+++ b/Number.vue
@@ -1,5 +1,7 @@
 <template>
-    <span>{{ tweenedNumber }}</span>
+  <component :is="is">
+    {{ tweenedNumber }}
+  </component>
 </template>
 
 <script>
@@ -35,10 +37,14 @@ export default {
       type: Number,
       default: 0 // Delay the animation in seconds
     },
+    is: {
+      type: String,
+      default: 'span'
+    },
     animationPaused: Boolean // Stops animation before start
   },
   data() {
-    return { 
+    return {
       fromProp: this.from
     }
   },

--- a/Number.vue
+++ b/Number.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="is">
+  <component :is="tag">
     {{ tweenedNumber }}
   </component>
 </template>
@@ -37,7 +37,7 @@ export default {
       type: Number,
       default: 0 // Delay the animation in seconds
     },
-    is: {
+    tag: {
       type: String,
       default: 'span'
     },


### PR DESCRIPTION
Hi everyone! Today I faced a problem when trying to render `<number ...>` component into my SVG. I needed to render a `<text>` element, but couldn't make it works because this lib forcibly renders a `<span>` tag as a root element. 

With this PR we make the root tag dynamic and anyone can replace it by passing `:is` attribute to `<number ...>`

## Usage

```js
<number
  is="text"
  ...
/>
```

PS: The default is `span`